### PR TITLE
Some fixes

### DIFF
--- a/Type.hs
+++ b/Type.hs
@@ -71,8 +71,11 @@ instantiateL gamma alpha a =
     Just gamma' -> return gamma'
     Nothing -> case a of
       -- InstLReach
-      TExists beta | ordered gamma alpha beta ->
-        return $ fromJust $ solve gamma beta (TExists alpha)
+      TExists beta 
+        | ordered gamma alpha beta ->
+            return $ fromJust $ solve gamma beta (TExists alpha)
+        | otherwise ->
+            return $ fromJust $ solve gamma alpha (TExists beta)
       -- InstLArr
       TFun a1 a2   -> do
         alpha1 <- freshTVar
@@ -106,8 +109,11 @@ instantiateR gamma a alpha =
     Just gamma' -> return gamma'
     Nothing -> case a of
       -- InstRReach
-      TExists beta | ordered gamma alpha beta -> return $
-        fromJust $ solve gamma beta (TExists alpha)
+      TExists beta 
+        | ordered gamma alpha beta ->
+            return $ fromJust $ solve gamma beta (TExists alpha)
+        | otherwise ->
+            return $ fromJust $ solve gamma alpha (TExists beta)
       -- InstRArr
       TFun a1 a2   -> do
         alpha1 <- freshTVar


### PR DESCRIPTION
Hi,

In some cases subtype fails to solve "a^ = a" where "a^" is existential and "a" is universal. For example:

```
print $ evalNameGen $ subtype mempty (tforall "a" $ tvar"a") (tforall "a" $ tvar"a") -- throws an error
```

The reason is that subtype checks "<:forallL" before "<:forallR", therefore the universal variables introduced by "<:forallR" are not in the visible context for the existentials. 

Switching the order of the two cases solves the issue. 
