### PR TITLE
Make projects build with newer GHCs

### DIFF
--- a/AST.hs
+++ b/AST.hs
@@ -2,6 +2,7 @@
 -- | Abstract syntax
 module AST where
 import Control.Applicative
+import Data.Semigroup
 import Data.Monoid
 import Data.Set(Set)
 import qualified Data.Set as S
@@ -131,6 +132,7 @@ deriving instance Eq (ContextElem a)
 deriving instance Show (ContextElem a)
 
 newtype GContext a      = Context [ContextElem a]
+  deriving Show
 type CompleteContext = GContext Complete
 type Context         = GContext Incomplete
 
@@ -151,6 +153,9 @@ dropMarker m (Context gamma) = Context $ tail $ dropWhile (/= m) gamma
 breakMarker :: ContextElem a -> GContext a -> (GContext a, GContext a)
 breakMarker m (Context xs) = let (r, _:l) = break (== m) xs in (Context l, Context r)
 
+instance Semigroup (GContext a) where
+  Context gamma <> Context delta = Context (delta ++ gamma)
+
 instance Monoid (GContext a) where
   mempty = Context []
-  mappend (Context gamma) (Context delta) = Context (delta ++ gamma)
+  mappend = (<>)

--- a/NameGen.hs
+++ b/NameGen.hs
@@ -30,16 +30,22 @@ evalNameGen = flip evalState initialNameState
 -- | Create a fresh variable
 freshVar :: NameGen Var
 freshVar = do
-  v:vs <- gets varNames
-  modify $ \s -> s {varNames = vs}
-  return v
+  vs0 <- gets varNames
+  case vs0 of
+    [] -> error "freshVar: encountered empty list"
+    v:vs -> do
+      modify $ \s -> s {varNames = vs}
+      return v
 
 -- | Create a fresh type variable
 freshTVar :: NameGen TVar
 freshTVar = do
-  v:vs <- gets tvarNames
-  modify $ \s -> s {tvarNames = vs}
-  return v
+  vs0 <- gets tvarNames
+  case vs0 of
+    [] -> error "freshTVar: encountered empty list"
+    v:vs -> do
+      modify $ \s -> s {tvarNames = vs}
+      return v
 
 -- | Print some debugging info
 traceNS :: (Pretty a, Pretty b) => String -> a -> NameGen b -> NameGen b


### PR DESCRIPTION
In particular, the implementation of Semigroup Monoid Proposal and MonadFail proposal caused this project to fail to build. Additionally, the trivial Show instance for GContext has been added.